### PR TITLE
Fix Isolate mixin testing

### DIFF
--- a/src/mixins/isolatable.ts
+++ b/src/mixins/isolatable.ts
@@ -130,7 +130,7 @@ export function IsolatedTest<T extends Constructor<Test>>(TestImplementation: T)
 
     protected async receiveMessagePort(): Promise<MessagePort> {
       // Step 3: the isolated context notifies that it is ready to proceed:
-      window.postMessage(IsolatedTestMessage.ready, window.location.origin);
+      window.parent.postMessage(IsolatedTestMessage.ready, window.location.origin);
 
       return new Promise(resolve => {
         const receiveMessage = (event: MessageEvent) => {


### PR DESCRIPTION
Make sure the "ready" message from the isolate iframe is set to the
parent window, not to the iframe window.